### PR TITLE
feat: install plasma-nm-openvpn

### DIFF
--- a/build_files/desktop/install-kde-packages.sh
+++ b/build_files/desktop/install-kde-packages.sh
@@ -102,7 +102,8 @@ dnf5 install -y --skip-broken \
 # Network and connectivity
 dnf5 install -y --skip-broken \
     bluedevil \
-    powerdevil
+    powerdevil \
+    plasma-nm-openvpn
 
 # Terminal emulator (Ptyxis is already in base, keep Konsole as option)
 # Both terminals will be available, users can choose


### PR DESCRIPTION
Adds `plasma-nm-openvpn` to the KDE desktop package installation script to enable OpenVPN support in the Plasma NetworkManager applet.